### PR TITLE
feat: add ruler stdout sink to helm chart

### DIFF
--- a/helm/templates/crs/ruler.yaml
+++ b/helm/templates/crs/ruler.yaml
@@ -33,14 +33,22 @@ spec:
   ruleSelector:
 {{ toYaml .Values.ruler.ruleSelector | indent 4 }}
   sinks:
+    {{- with .Values.ruler.sinks.alertmanager }}
+    alertmanager:
+{{ toYaml . | indent 6 }}
+    {{- end }}
     {{- if not (empty .Values.ruler.sinks.alertmanagers) }}
     alertmanagers:
 {{ toYaml .Values.ruler.sinks.alertmanagers | indent 4 }}
-    {{- end}}
+    {{- end }}
     {{- if not (empty .Values.ruler.sinks.webhooks) }}
     {{- with .Values.ruler.sinks.webhooks }}
     webhooks:
 {{ toYaml . | indent 4 }}
     {{- end }}
-    {{- end}}
+    {{- end }}
+    {{- with .Values.ruler.sinks.stdout }}
+    stdout:
+{{ toYaml . | indent 6 }}
+    {{- end }}
 {{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -70,10 +70,13 @@ ruler:
   ruleNamespaceSelector: {}
   ruleSelector: {}
   sinks:
-    alertmanagers:
-    - namespace: kubesphere-monitoring-system
+    alertmanager:
+      namespace: kubesphere-monitoring-system
       name: alertmanager-operated
-    webhooks: []
+    # alertmanagers:
+    # - namespace: kubesphere-monitoring-system
+    #   name: alertmanager-operated
+    # webhooks:
     # - type:
     #   url:
     #   service:
@@ -81,7 +84,9 @@ ruler:
     #     name:
     #     port:
     #     path:
-
+    ## 'stdout' sink type can be either 'notification' or 'alert'
+    # stdout:
+    #   type: notification
 rule:
   createDefaults: true
   overrideDefaults: false


### PR DESCRIPTION
- add ruler stdout sink to helm chart
- restore alertmanager~s~ sink to helm chart (deprecated but not deleted, `alertmanagers` is not supported by the latest release) 