### PR TITLE
clean managedFields in exported events

### DIFF
--- a/pkg/exporter/kube_events_exporter.go
+++ b/pkg/exporter/kube_events_exporter.go
@@ -161,6 +161,7 @@ func (s *K8sEventSource) enqueueEvent(obj interface{}) {
 	}
 	evt, ok := obj.(*corev1.Event)
 	if ok {
+		evt.SetManagedFields(nil) // set it nil because it is quite verbose
 		s.workqueue.Add(evt)
 	}
 }


### PR DESCRIPTION
The `metadata.managedFields` in exported events is quite verbose and generally useless for event analysis, so clean it.