### PR TITLE
support new event version

### DIFF
--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -26,7 +26,7 @@ func init() {
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
 	flag.StringVar(&masterURL, "master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
 	flag.StringVar(&configFile, "config.file", "", "Event exporter configuration file path")
-	flag.BoolVar(&util.NewEventType, "newEventType", false, "if true, exporter will use new event type")
+	flag.StringVar(&util.EventVersion, "event.version", util.EventVersionOld, "event version, eventsv1 or corev1")
 }
 
 func main() {

--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -26,6 +26,7 @@ func init() {
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
 	flag.StringVar(&masterURL, "master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
 	flag.StringVar(&configFile, "config.file", "", "Event exporter configuration file path")
+	flag.BoolVar(&util.NewEventType, "newEventType", false, "if true, exporter will use new event type")
 }
 
 func main() {
@@ -41,6 +42,8 @@ func main() {
 	if e != nil {
 		klog.Fatal("Error building kubernetes clientset: ", e)
 	}
+
+	go util.SetClusterName(kclient)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	wg, ctx := errgroup.WithContext(ctx)

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	k8s.io/apimachinery v0.27.4
 	k8s.io/client-go v12.0.0+incompatible
 	k8s.io/klog v1.0.0
+	k8s.io/klog/v2 v2.90.1
 	sigs.k8s.io/controller-runtime v0.14.6
 	sigs.k8s.io/yaml v1.4.0
 )
@@ -114,7 +115,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.26.1 // indirect
 	k8s.io/component-base v0.26.1 // indirect
-	k8s.io/klog/v2 v2.90.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20230501164219-8b0f38b5fd1f // indirect
 	k8s.io/utils v0.0.0-20230209194617-a36077c30491 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect

--- a/pkg/exporter/kube_events_exporter.go
+++ b/pkg/exporter/kube_events_exporter.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
+
 	"github.com/kubesphere/kube-events/pkg/util"
-	v1 "k8s.io/api/events/v1"
+	eventsv1 "k8s.io/api/events/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sync"
 
 	"github.com/kubesphere/kube-events/pkg/config"
 	"github.com/kubesphere/kube-events/pkg/exporter/sinks"
@@ -204,8 +205,8 @@ func NewKubeEventSource(client *kubernetes.Clientset) *K8sEventSource {
 	}
 	var eventType runtime.Object
 	var lw *cache.ListWatch
-	if util.NewEventType {
-		eventType = &v1.Event{}
+	if util.EventVersion == util.EventVersionNew {
+		eventType = &eventsv1.Event{}
 		lw = cache.NewListWatchFromClient(client.EventsV1().RESTClient(),
 			"events", metav1.NamespaceAll, fields.Everything())
 	} else {

--- a/pkg/exporter/types/types.go
+++ b/pkg/exporter/types/types.go
@@ -2,8 +2,7 @@ package types
 
 import (
 	"context"
-
-	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type Events struct {
@@ -11,8 +10,8 @@ type Events struct {
 }
 
 type ExtendedEvent struct {
-	*v1.Event `json:",inline"`
-	Cluster   string `json:"cluster,omitempty"`
+	Event   client.Object `json:",inline"`
+	Cluster string        `json:"cluster,omitempty"`
 }
 
 type Sinker interface {

--- a/pkg/util/annoutil.go
+++ b/pkg/util/annoutil.go
@@ -1,0 +1,43 @@
+package util
+
+import (
+	"context"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+)
+
+var cluster string
+var NewEventType bool
+
+func SetClusterName(client *kubernetes.Clientset) {
+	setCluster(client)
+	c := time.Tick(60 * time.Second)
+	for {
+		select {
+		case <-c:
+			setCluster(client)
+			klog.Infof("current cluster is [%s]", GetCluster())
+		}
+	}
+
+}
+
+func setCluster(client *kubernetes.Clientset) {
+
+	ns, err := client.CoreV1().Namespaces().Get(context.Background(), "kubesphere-system", metav1.GetOptions{})
+	if err != nil {
+		klog.Errorf("get namespace kubesphere-system error: %s", err)
+	}
+
+	if ns.Annotations != nil {
+		cluster = ns.Annotations["cluster.kubesphere.io/name"]
+	}
+
+}
+
+func GetCluster() string {
+	return cluster
+}


### PR DESCRIPTION
* 支持导出新事件，设置 `newEventType` 参数为 `true` 开启，默认为 `false`
* 定时获取 cluster name

旧版事件输出
```json
{"metadata":{"name":"ks-apiserver-7b94f9bd6f-vbtfp.17e9145e250bdcef","namespace":"kubesphere-system","uid":"40fa04c5-66f2-4c6e-8201-3b13b17dbc35","resourceVersion":"8460007","creationTimestamp":"2024-08-06T07:52:07Z"},"involvedObject":{"kind":"Pod","namespace":"kubesphere-system","name":"ks-apiserver-7b94f9bd6f-vbtfp","uid":"0ec6bbc8-9ba1-42f9-87b0-0dcfa99c0c57","apiVersion":"v1","resourceVersion":"8305839"},"reason":"FailedScheduling","message":"0/1 nodes are available: 1 node(s) didn't match pod anti-affinity rules.","source":{},"firstTimestamp":null,"lastTimestamp":null,"type":"Warning","eventTime":"2024-08-06T07:52:07.026936Z","series":{"count":1013,"lastObservedTime":"2024-08-07T01:32:29.267628Z"},"action":"Scheduling","reportingComponent":"default-scheduler","reportingInstance":"default-scheduler-i-bhbpy0xx","cluster":"host"}
```
新版事件输出
```json
{"metadata":{"name":"ks-apiserver-7b94f9bd6f-vbtfp.17e9145e250bdcef","namespace":"kubesphere-system","uid":"40fa04c5-66f2-4c6e-8201-3b13b17dbc35","resourceVersion":"8460007","creationTimestamp":"2024-08-06T07:52:07Z"},"eventTime":"2024-08-06T07:52:07.026936Z","series":{"count":1013,"lastObservedTime":"2024-08-07T01:32:29.267628Z"},"reportingController":"default-scheduler","reportingInstance":"default-scheduler-i-bhbpy0xx","action":"Scheduling","reason":"FailedScheduling","regarding":{"kind":"Pod","namespace":"kubesphere-system","name":"ks-apiserver-7b94f9bd6f-vbtfp","uid":"0ec6bbc8-9ba1-42f9-87b0-0dcfa99c0c57","apiVersion":"v1","resourceVersion":"8305839"},"note":"0/1 nodes are available: 1 node(s) didn't match pod anti-affinity rules.","type":"Warning","deprecatedSource":{},"deprecatedFirstTimestamp":null,"deprecatedLastTimestamp":null,"cluster":"host"}
```